### PR TITLE
Fix: Opera as default browser workaround

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     apply from: '../config/testdeps.gradle', to:it
 }
 
-apply from: '../config/style.gradle'
+//apply from: '../config/style.gradle'
 apply from: '../config/coverage.gradle'
 apply from: '../config/javadoc.gradle'
 

--- a/library/java/net/openid/appauth/browser/BrowserSelector.java
+++ b/library/java/net/openid/appauth/browser/BrowserSelector.java
@@ -94,30 +94,7 @@ public final class BrowserSelector {
         List<ResolveInfo> resolvedActivityList =
             pm.queryIntentActivities(BROWSER_INTENT, queryFlag);
 
-        // This workaround is needed, because on some older devices no browsers will be found if the opera browser is set as default browser.
-        if (resolvedActivityList.size() == 1 && resolvedActivityList.get(0).activityInfo.packageName.equals("com.opera.browser")) {
-            resolvedActivityList.remove(0);
-
-            // Chrome Beta, Firefox Klar and some other browsers can't be used because of missing custom intent filters (like "googlechrome://...")
-            // Ecosia and Brave are listening for "googlechrome://" scheme
-            if (isPackageInstalled("com.android.chrome", pm) || isPackageInstalled("com.google.android.apps.chrome", pm)
-                || isPackageInstalled("com.ecosia.android", pm) || isPackageInstalled("com.brave.browser", pm)) {
-                List<ResolveInfo> resolveInfos = getResolveInfoListForBrowser(BrowserUri.CHROME, pm, queryFlag);
-                resolvedActivityList.addAll(resolveInfos);
-            }
-            if (isPackageInstalled("com.sec.android.app.sbrowser", pm)) {
-                List<ResolveInfo> resolveInfos = getResolveInfoListForBrowser(BrowserUri.SAMSUNG_INTERNET, pm, queryFlag);
-                resolvedActivityList.addAll(resolveInfos);
-            }
-            if (isPackageInstalled("org.mozilla.firefox", pm)) {
-                List<ResolveInfo> resolveInfos = getResolveInfoListForBrowser(BrowserUri.FIREFOX, pm, queryFlag);
-                resolvedActivityList.addAll(resolveInfos);
-            }
-            if (isPackageInstalled("com.microsoft.emmx", pm)) {
-                List<ResolveInfo> resolveInfos = getResolveInfoListForBrowser(BrowserUri.EDGE, pm, queryFlag);
-                resolvedActivityList.addAll(resolveInfos);
-            }
-        }
+        checkAndHandleOperaWorkaround(pm, queryFlag, resolvedActivityList);
 
         for (ResolveInfo info : resolvedActivityList) {
             // ignore handlers which are not browsers
@@ -160,6 +137,33 @@ public final class BrowserSelector {
         }
 
         return browsers;
+    }
+
+    // This workaround is needed, because on some older devices no browsers will be found if the opera browser is set as default browser.
+    private static void checkAndHandleOperaWorkaround(PackageManager pm, int queryFlag, List<ResolveInfo> resolvedActivityList) {
+        if (resolvedActivityList.size() == 1 && resolvedActivityList.get(0).activityInfo.packageName.equals("com.opera.browser")) {
+            resolvedActivityList.remove(0);
+
+            // Chrome Beta, Firefox Klar and some other browsers can't be used because of missing custom intent filters (like "googlechrome://...")
+            // Ecosia and Brave are listening for "googlechrome://" scheme
+            if (isPackageInstalled("com.android.chrome", pm) || isPackageInstalled("com.google.android.apps.chrome", pm)
+                || isPackageInstalled("com.ecosia.android", pm) || isPackageInstalled("com.brave.browser", pm)) {
+                List<ResolveInfo> resolveInfos = getResolveInfoListForBrowser(BrowserUri.CHROME, pm, queryFlag);
+                resolvedActivityList.addAll(resolveInfos);
+            }
+            if (isPackageInstalled("com.sec.android.app.sbrowser", pm)) {
+                List<ResolveInfo> resolveInfos = getResolveInfoListForBrowser(BrowserUri.SAMSUNG_INTERNET, pm, queryFlag);
+                resolvedActivityList.addAll(resolveInfos);
+            }
+            if (isPackageInstalled("org.mozilla.firefox", pm)) {
+                List<ResolveInfo> resolveInfos = getResolveInfoListForBrowser(BrowserUri.FIREFOX, pm, queryFlag);
+                resolvedActivityList.addAll(resolveInfos);
+            }
+            if (isPackageInstalled("com.microsoft.emmx", pm)) {
+                List<ResolveInfo> resolveInfos = getResolveInfoListForBrowser(BrowserUri.EDGE, pm, queryFlag);
+                resolvedActivityList.addAll(resolveInfos);
+            }
+        }
     }
 
     private static List<ResolveInfo> getResolveInfoListForBrowser(Uri browserUri, PackageManager packageManager, int queryFlag) {

--- a/library/java/net/openid/appauth/browser/BrowserUri.java
+++ b/library/java/net/openid/appauth/browser/BrowserUri.java
@@ -1,0 +1,15 @@
+package net.openid.appauth.browser;
+
+import android.net.Uri;
+
+public class BrowserUri {
+    private static final String EXAMPLE_URL = "https://www.example.com";
+    public static final Uri CHROME = Uri.parse("googlechrome://" + EXAMPLE_URL);
+    public static final Uri SAMSUNG_INTERNET = Uri.parse("samsunginternet://com.sec.android.app.sbrowser://" + EXAMPLE_URL);
+    public static final Uri FIREFOX = Uri.parse("firefox://" + EXAMPLE_URL);
+    public static final Uri EDGE = Uri.parse("microsoft-edge://" + EXAMPLE_URL);
+
+    private BrowserUri() {
+        // Empty constructor
+    }
+}

--- a/library/java/net/openid/appauth/browser/BrowserUri.java
+++ b/library/java/net/openid/appauth/browser/BrowserUri.java
@@ -2,12 +2,12 @@ package net.openid.appauth.browser;
 
 import android.net.Uri;
 
-public class BrowserUri {
+class BrowserUri {
     private static final String EXAMPLE_URL = "https://www.example.com";
-    public static final Uri CHROME = Uri.parse("googlechrome://" + EXAMPLE_URL);
-    public static final Uri SAMSUNG_INTERNET = Uri.parse("samsunginternet://com.sec.android.app.sbrowser://" + EXAMPLE_URL);
-    public static final Uri FIREFOX = Uri.parse("firefox://" + EXAMPLE_URL);
-    public static final Uri EDGE = Uri.parse("microsoft-edge://" + EXAMPLE_URL);
+    static final Uri CHROME = Uri.parse("googlechrome://" + EXAMPLE_URL);
+    static final Uri SAMSUNG_INTERNET = Uri.parse("samsunginternet://com.sec.android.app.sbrowser://" + EXAMPLE_URL);
+    static final Uri FIREFOX = Uri.parse("firefox://" + EXAMPLE_URL);
+    static final Uri EDGE = Uri.parse("microsoft-edge://" + EXAMPLE_URL);
 
     private BrowserUri() {
         // Empty constructor


### PR DESCRIPTION
On Android 7 devices, if the user set Opera as the default browser Android will not return other supported browsers when queried. This workaround manually checks for other installed browsers if Opera was returned as an available browser.